### PR TITLE
Add a page at '/' with a button to generate PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm start
 
 The server will be running on `http://localhost:3000`.
 
-## Endpoint
+## Endpoints
 
 ### `GET /create-pdf`
 
@@ -34,3 +34,9 @@ Example request:
 ```sh
 curl http://localhost:3000/create-pdf --output hello.pdf
 ```
+
+### `GET /`
+
+This endpoint serves a page with a button that calls `/create-pdf` to generate a PDF. When the button is clicked, the generated PDF will open in a new tab.
+
+To use this endpoint, open your browser and navigate to `http://localhost:3000/`. Click the "Generate PDF" button to generate and view the PDF.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 const express = require('express');
 const { PDFDocument } = require('pdf-lib');
+const path = require('path');
 
 const app = express();
+
+app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/create-pdf', async (req, res) => {
   const pdfDoc = await PDFDocument.create();
@@ -16,6 +19,10 @@ app.get('/create-pdf', async (req, res) => {
 
   res.setHeader('Content-Type', 'application/pdf');
   res.send(Buffer.from(pdfBytes));
+});
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 const PORT = process.env.PORT || 3000;

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF Generator</title>
+</head>
+<body>
+    <button id="generate-pdf">Generate PDF</button>
+
+    <script>
+        document.getElementById('generate-pdf').addEventListener('click', function() {
+            window.open('/create-pdf', '_blank');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add a new page at "/" with a button that calls "/create-pdf".

* **index.js**
  - Add an endpoint to serve a page at "/" with a button that calls "/create-pdf".
  - Use `express.static` to serve static files from the `public` directory.

* **public/index.html**
  - Create an HTML file with a button that calls "/create-pdf".
  - Add a script to handle the button click and open the generated PDF in a new tab.

* **README.md**
  - Update the documentation to include the new "/" endpoint and instructions on how to use the button to generate the PDF.

