### PR TITLE
Update trigger-event API to separate PDF generation and event triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,8 @@ Example request:
 curl http://localhost:3000/create-pdf --output hello.pdf
 ```
 
-### `GET /trigger-event`
-
-This endpoint generates a PDF with the text "Event Triggered PDF", adds the PDF data to an event, and triggers the event. The response is a message indicating that the event was triggered and the PDF was generated.
-
-Example request:
-```sh
-curl http://localhost:3000/trigger-event
-```
-
 ### `GET /`
 
-This endpoint serves a page with buttons that call `/create-pdf` and `/trigger-event` to generate PDFs. When the "Generate PDF" button is clicked, the generated PDF will open in a new tab. When the "Trigger Event" button is clicked, an event will be triggered and a message will be displayed.
+This endpoint serves a page with buttons that call `/create-pdf` to generate PDFs. When the "Generate PDF" button is clicked, the generated PDF will open in a new tab. When the "Trigger Event" button is clicked, the PDF will be generated, added to an event, and the event will be triggered.
 
-To use this endpoint, open your browser and navigate to `http://localhost:3000/`. Click the "Generate PDF" button to generate and view the PDF. Click the "Trigger Event" button to trigger the event and display the message.
+To use this endpoint, open your browser and navigate to `http://localhost:3000/`. Click the "Generate PDF" button to generate and view the PDF. Click the "Trigger Event" button to generate the PDF, add it to an event, and trigger the event.

--- a/index.js
+++ b/index.js
@@ -21,29 +21,6 @@ app.get('/create-pdf', async (req, res) => {
   res.send(Buffer.from(pdfBytes));
 });
 
-app.get('/trigger-event', async (req, res) => {
-  const pdfDoc = await PDFDocument.create();
-  const page = pdfDoc.addPage([600, 400]);
-  page.drawText('Event Triggered PDF', {
-    x: 50,
-    y: 350,
-    size: 30,
-  });
-
-  const pdfBytes = await pdfDoc.save();
-
-  // Add PDF data to event
-  const event = {
-    type: 'PDF_GENERATED',
-    data: Buffer.from(pdfBytes)
-  };
-
-  // Trigger the event
-  console.log('Event triggered:', event);
-
-  res.send('Event triggered and PDF generated');
-});
-
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });

--- a/public/index.html
+++ b/public/index.html
@@ -15,9 +15,12 @@
         });
 
         document.getElementById('trigger-event').addEventListener('click', function() {
-            fetch('/trigger-event')
-                .then(response => response.text())
-                .then(data => alert(data));
+            fetch('/create-pdf')
+                .then(response => response.blob())
+                .then(blob => {
+                    const event = new CustomEvent('pdfGenerated', { detail: blob });
+                    document.dispatchEvent(event);
+                });
         });
     </script>
 </body>


### PR DESCRIPTION
Remove the `/trigger-event` endpoint and update the main page to handle event triggering.

* **index.js**
  - Remove the `/trigger-event` endpoint.

* **public/index.html**
  - Update the `trigger-event` button to call the `create-pdf` endpoint.
  - Add the output of the API call to an event and trigger the event.

* **README.md**
  - Remove the description of the `/trigger-event` endpoint.
  - Update the instructions for using the buttons on the main page.

