### PR TITLE
Add button to generate PDF from URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
 <body>
     <button id="generate-pdf">Generate PDF</button>
     <button id="trigger-event">Trigger Event</button>
+    <button id="generate-pdf-from-url">Generate PDF from URL</button>
 
     <script>
         document.getElementById('generate-pdf').addEventListener('click', function() {
@@ -16,6 +17,17 @@
 
         document.getElementById('trigger-event').addEventListener('click', function() {
             fetch('/create-pdf')
+                .then(response => response.arrayBuffer())
+                .then(buffer => {
+                    console.log("firing events");
+                    const base64 = btoa(new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), ''));
+                    window.webkit.messageHandlers.cordova_iab.postMessage(JSON.stringify({ action:"pdfGenerated", type: 'pdfGenerated', pdf: base64 }));
+                    window.postMessage({ type: 'pdfGenerated', pdf: base64 }, '*');
+                });
+        });
+
+        document.getElementById('generate-pdf-from-url').addEventListener('click', function() {
+            fetch('https://pa529.com/pdf/gsp/GSP-Disclosure-statement.pdf')
                 .then(response => response.arrayBuffer())
                 .then(buffer => {
                     console.log("firing events");


### PR DESCRIPTION
Add a new button to generate PDF from a URL.

* **HTML Changes**
  - Add a new button with id `generate-pdf-from-url`.
  - Add an event listener for the new button to fetch the PDF from the URL `https://pa529.com/pdf/gsp/GSP-Disclosure-statement.pdf` and fire an event similar to the `trigger-event` code block.

