### PR TITLE
Update generate-pdf-from-url to call new endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ app.get('/create-pdf', async (req, res) => {
   res.send(Buffer.from(pdfBytes));
 });
 
+app.get('/get-pdf', (req, res) => {
+  const filePath = path.join(__dirname, 'public', 'GSP-Disclosure-statement.pdf');
+  res.setHeader('Content-Type', 'application/pdf');
+  res.sendFile(filePath);
+});
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
         });
 
         document.getElementById('generate-pdf-from-url').addEventListener('click', function() {
-            fetch('https://pa529.com/pdf/gsp/GSP-Disclosure-statement.pdf')
+            fetch('/get-pdf')
                 .then(response => response.arrayBuffer())
                 .then(buffer => {
                     console.log("firing events");


### PR DESCRIPTION
Add a new endpoint `/get-pdf` to return the PDF located at `public/GSP-Disclosure-statement.pdf`.

* Set the `Content-Type` header to `application/pdf` in the new endpoint.
* Update the `generate-pdf-from-url` button click event in `public/index.html` to call the new `/get-pdf` endpoint instead of the external URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/imbeyondboredom/pdf-generator/pull/7?shareId=3a8910c5-2f81-4b43-a5ec-83b2f19c485e).